### PR TITLE
[CAD-3907] check to see if stat result is nil

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -35,7 +35,7 @@ func (gcsDriver *GCSArtifactDriver) saveToFile(inputArtifact *wfv1.Artifact, fil
 		return err
 	}
 
-	if stat.IsDir() {
+	if stat != nil && stat.IsDir() {
 		return errors.New("output artifact path is a directory")
 	}
 


### PR DESCRIPTION
If the file doesn't exist, the return value of os.Stat is nil, which is actually what we want. we need to do a nil check before looking for an error code so that the exec container doesnt panic. 