### PR TITLE
Semantic version tagging of argo components

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,11 @@ pipeline {
                     IMAGE_TAG=IMAGE_REF.split(':').last()
                     GIT_BRANCH = env.BRANCH_NAME.replace('/', '').replace('_', '').replace('-', '')
 
-                    if (env.BRANCH_NAME == 'master') {
-                        VERSION = env.BUILD_ID}
-                    else {
-                        VERSION = env.BUILD_ID +  GIT_BRANCH
-                    }
+                    def baseVersionTag = readFile "VERSION"
+                    baseVersionTag = baseVersionTag.trim();
+                    VERSION = "${baseVersionTag}-cyrus-${GIT_BRANCH}"
+
+                    println "Version tag for this build is ${VERSION}"
                 }
             }
         }


### PR DESCRIPTION
This PR causes CLI versions and docker containers to be tagged `<major>.<minor>.<patch>-cyrus-<branchname>`

the `<branchname>` tag reflects the fact that when we merge rc->release (for example) we're actually doing a new build