### PR TITLE
[CSE-14] Display new errors and warnings in the CLI

### DIFF
--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -46,6 +46,12 @@ const (
 	FgDefault = 39
 )
 
+//shorthands
+var (
+	YellowWarning = ansiFormat("⚠", FgYellow)
+	RedError      = ansiFormat("✖", FgRed)
+)
+
 func initializeSession() {
 	jobStatusIconMap = map[wfv1.NodePhase]string{
 		wfv1.NodePending:   ansiFormat("◷", FgYellow),

--- a/cmd/argo/commands/common.go
+++ b/cmd/argo/commands/common.go
@@ -46,7 +46,7 @@ const (
 	FgDefault = 39
 )
 
-//shorthands
+//useful icons
 var (
 	YellowWarning = ansiFormat("⚠", FgYellow)
 	RedError      = ansiFormat("✖", FgRed)

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -114,6 +114,27 @@ func printWorkflowHelper(wf *wfv1.Workflow, outFmt string) {
 			}
 		}
 	}
+
+	errorWriter := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	if wf.Status.Errors != nil || wf.Status.Warnings != nil {
+
+		fmt.Fprint(errorWriter, "  STEP\tPODNAME\tCODE\tMESSAGE\n")
+	}
+
+	if wf.Status.Errors != nil {
+		for _, errorResult := range wf.Status.Errors {
+			fmt.Fprintf(errorWriter, "%s %s\t%s\t%s\t%s\n", RedError, errorResult.StepName, errorResult.PodId, errorResult.Name, errorResult.Message)
+		}
+	}
+
+	if wf.Status.Warnings != nil {
+		for _, warningResult := range wf.Status.Warnings {
+			fmt.Fprintf(errorWriter, "%s %s\t%s\t%s\t%s\n", YellowWarning, warningResult.StepName, warningResult.PodId, warningResult.Name, warningResult.Message)
+		}
+	}
+	_ = errorWriter.Flush()
+
 	printTree := true
 	if wf.Status.Nodes == nil {
 		printTree = false

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -119,7 +119,8 @@ func printWorkflowHelper(wf *wfv1.Workflow, outFmt string) {
 
 	if wf.Status.Errors != nil || wf.Status.Warnings != nil {
 
-		fmt.Fprint(errorWriter, "  STEP\tPODNAME\tCODE\tMESSAGE\n")
+		fmt.Printf("\nErrors and Warnings:\n")
+		fmt.Fprintf(errorWriter, "%s\tPODNAME\tCODE\tMESSAGE\n", ansiFormat("STEP", FgDefault))
 	}
 
 	if wf.Status.Errors != nil {


### PR DESCRIPTION
_This PR is open against #16 for review, it should be merged into `rc`_

Here, we prettyprint the errors and warnings added in #16 into a table. the table looks like this:
<img width="1044" alt="Screen Shot 2019-03-14 at 4 33 16 PM" src="https://user-images.githubusercontent.com/455324/54398662-34f4f780-4678-11e9-802f-ae138b014b36.png">
